### PR TITLE
Rename MenuLinkerApp to TopDoorApp

### DIFF
--- a/topDoor/topDoorApp.swift
+++ b/topDoor/topDoorApp.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import Combine
 
 @main
-struct MenuLinkerApp: App {
+struct TopDoorApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
     
     var body: some Scene {


### PR DESCRIPTION
## Summary
- rename `MenuLinkerApp` to `TopDoorApp` in the main application entry point

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_b_684da0077f8c832badb750c5eb499596