### PR TITLE
Fix NSWorkspace open method

### DIFF
--- a/topDoor/LinkModel.swift
+++ b/topDoor/LinkModel.swift
@@ -94,7 +94,12 @@ class LinkManager: ObservableObject {
             NSWorkspace.shared.open(url)
         case .file:
             if let openWith = link.openWith, !openWith.isEmpty {
-                NSWorkspace.shared.openFile(link.url, withApplication: openWith)
+                let fileURL = URL(fileURLWithPath: link.url)
+                let appURL = URL(fileURLWithPath: openWith)
+                let configuration = NSWorkspace.OpenConfiguration()
+                NSWorkspace.shared.open([fileURL], withApplicationAt: appURL,
+                                        configuration: configuration,
+                                        completionHandler: nil)
             } else {
                 let url = URL(fileURLWithPath: link.url)
                 NSWorkspace.shared.open(url)


### PR DESCRIPTION
## Summary
- address deprecation warning for file opening API

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_b_684db49df8d0832b8624288d5ec17bfc