### PR TITLE
Fix macOS EditButton issue

### DIFF
--- a/topDoor/LinkEditView.swift
+++ b/topDoor/LinkEditView.swift
@@ -34,7 +34,9 @@ struct LinkEditView: View {
             .padding()
         }
         .frame(minWidth: 400, minHeight: 300)
-        .toolbar { EditButton() }
+        // macOS では EditButton が提供されていないため、
+        // 編集モード用のボタンは表示しない
+        // .toolbar { EditButton() }
     }
 
     private func addNewLink() {


### PR DESCRIPTION
## Summary
- remove EditButton usage that relies on unavailable EditMode on macOS

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684dc2e7afb8832b8995fad0ab902891